### PR TITLE
perf: typecheck before linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "serve": "sirv public --single --host",
     "serve:dev": "sirv public --single --host --dev",
     "typecheck": "tsc --noEmit",
-    "validate": "run-p lint typecheck",
+    "validate": "run-s typecheck lint",
     "watch": "rollup -c rollup.config.dev.js -w"
   },
   "devDependencies": {


### PR DESCRIPTION
tsc is usually faster than the eslint.
Serially run typecheck and lint
which ensures that it only lints after typecheck has succeeded.